### PR TITLE
Additional bridge metrics

### DIFF
--- a/mausignald/rpc.py
+++ b/mausignald/rpc.py
@@ -73,11 +73,11 @@ class SignaldRPCClient:
                 self._reader, self._writer = await asyncio.open_unix_connection(
                     self.socket_path, limit=_SOCKET_LIMIT)
             except OSError as e:
-                self.log.error(f"Connection to {self.socket_path} failed: {e}")
+                self.log.error(f"Connection to {self.socket_path} failed: {e}, retrying in 5s")
                 await asyncio.sleep(5)
                 continue
-            self.log.info(f"Connection to {self.socket_path} succeeded")
 
+            self.log.info(f"Connection to {self.socket_path} succeeded")
             read_loop = asyncio.create_task(self._try_read_loop())
             self.is_connected = True
             CONNECTED_GAUGE.set(1)

--- a/mausignald/rpc.py
+++ b/mausignald/rpc.py
@@ -117,7 +117,7 @@ class SignaldRPCClient:
         try:
             handlers = self._rpc_event_handlers[command]
         except KeyError:
-            EVENTS_COUNTER.labels("command", command).labels("result", "unhandled").inc()
+            EVENTS_COUNTER.labels(command=command, result="unhandled").inc()
             self.log.warning("No handlers for RPC request %s", command)
             self.log.trace("Data unhandled request: %s", req)
         else:
@@ -129,9 +129,9 @@ class SignaldRPCClient:
                     self.log.exception("Exception in RPC event handler")
                     error = True
             if error:
-                EVENTS_COUNTER.labels("command", command).labels("result", "error").inc()
+                EVENTS_COUNTER.labels(command=command, result="error").inc()
             else:
-                EVENTS_COUNTER.labels("command", command).labels("result", "success").inc()
+                EVENTS_COUNTER.labels(command=command, result="success").inc()
 
     def _run_response_handlers(self, req_id: UUID, command: str, req: Any) -> None:
         try:

--- a/mausignald/signald.py
+++ b/mausignald/signald.py
@@ -255,11 +255,11 @@ class SignaldClient(SignaldRPCClient):
                                          address=address.serialize(), **kwargs)
         except UnexpectedResponse as e:
             if e.resp_type == "profile_not_available":
-                PROFILE_RESULT_COUNTER.labels("result", "not-found").inc()
+                PROFILE_RESULT_COUNTER.labels(result="not-found").inc()
                 return None
-            PROFILE_RESULT_COUNTER.labels("result", "error").inc()
+            PROFILE_RESULT_COUNTER.labels(result="error").inc()
             raise
-        PROFILE_RESULT_COUNTER.labels("result", "found").inc()
+        PROFILE_RESULT_COUNTER.labels(result="found").inc()
         return Profile.deserialize(resp)
 
     async def get_identities(self, username: str, address: Address) -> GetIdentitiesResponse:

--- a/mausignald/signald.py
+++ b/mausignald/signald.py
@@ -122,6 +122,7 @@ class SignaldClient(SignaldRPCClient):
                 )
                 await self._run_event_handler(evt)
         RECONNECTIONS_COUNTER.inc(1)
+        await self.connect()
 
     async def register(self, phone: str, voice: bool = False, captcha: Optional[str] = None
                        ) -> str:

--- a/mausignald/signald.py
+++ b/mausignald/signald.py
@@ -7,6 +7,7 @@ from typing import Union, Optional, List, Dict, Any, Callable, Awaitable, Set, T
 import asyncio
 
 from mautrix.util.logging import TraceLogger
+from mautrix.util.opt_prometheus import Gauge, Counter
 
 from .rpc import CONNECT_EVENT, DISCONNECT_EVENT, SignaldRPCClient
 from .errors import UnexpectedError, UnexpectedResponse
@@ -17,6 +18,9 @@ from .types import (Address, Quote, Attachment, Reaction, Account, Message, Devi
 T = TypeVar('T')
 EventHandler = Callable[[T], Awaitable[None]]
 
+CONNECTED_GAUGE = Gauge("bridge_signal_connected", "Is the bridge connected to signald")
+RECONNECTIONS_COUNTER = Counter("bridge_signal_reconnections", "The number of reconnections made to signald")
+PROFILE_RESULT_COUNTER = Counter("bridge_signal_profile_result", "The result of profile requests made to signald", ["result"])
 
 class SignaldClient(SignaldRPCClient):
     _event_handlers: Dict[Type[T], List[EventHandler]]
@@ -99,12 +103,15 @@ class SignaldClient(SignaldRPCClient):
             return False
 
     async def _resubscribe(self, unused_data: Dict[str, Any]) -> None:
+        CONNECTED_GAUGE.set(1)
         if self._subscriptions:
             self.log.debug("Resubscribing to users")
             for username in list(self._subscriptions):
                 await self.subscribe(username)
 
     async def _on_disconnect(self, *_) -> None:
+        CONNECTED_GAUGE.set(0)
+        self.log.error("signald socket disconnected")
         if self._subscriptions:
             self.log.debug("Notifying of disconnection from users")
             for username in self._subscriptions:
@@ -114,6 +121,7 @@ class SignaldClient(SignaldRPCClient):
                     exception="Disconnected from signald"
                 )
                 await self._run_event_handler(evt)
+        RECONNECTIONS_COUNTER.inc(1)
 
     async def register(self, phone: str, voice: bool = False, captcha: Optional[str] = None
                        ) -> str:
@@ -252,8 +260,11 @@ class SignaldClient(SignaldRPCClient):
                                          address=address.serialize(), **kwargs)
         except UnexpectedResponse as e:
             if e.resp_type == "profile_not_available":
+                PROFILE_RESULT_COUNTER.labels("result", "not-found").inc()
                 return None
+            PROFILE_RESULT_COUNTER.labels("result", "error").inc()
             raise
+        PROFILE_RESULT_COUNTER.labels("result", "found").inc()
         return Profile.deserialize(resp)
 
     async def get_identities(self, username: str, address: Address) -> GetIdentitiesResponse:

--- a/mautrix_signal/__main__.py
+++ b/mautrix_signal/__main__.py
@@ -174,7 +174,7 @@ class SignalBridge(Bridge):
                 await asyncio.sleep(ACTIVE_USER_METRICS_INTERVAL_S)
             except asyncio.CancelledError:
                 return
-            log.info("Executing periodic active puppet metric check")
+            log.debug("Executing periodic active puppet metric check")
             try:
                 await self._update_active_puppet_metric(log)
             except asyncio.CancelledError:

--- a/mautrix_signal/signal.py
+++ b/mautrix_signal/signal.py
@@ -149,7 +149,7 @@ class SignalHandler(SignaldClient):
 
     async def start(self) -> None:
         await self.connect()
-        self.log.info("Connected to signald, now subscribing to users")
+        self.log.info("Subscribing to users")
         known_usernames = set()
         async for user in u.User.all_logged_in():
             # TODO report errors to user?


### PR DESCRIPTION
This change does two things:
- Adds a bunch of metrics around problem paths we've found. Notably disconnections and profile requests
- ~~Attempts to reconnect on disconnect, I don't know how successful this will be but worth a go?~~
  - I failed to read the code properly so this was ultimately unnecessary, nonetheless we've got logging for it now.