### PR TITLE
Add ability to disable invites tempoarily

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@ The Element fork includes the following changes:
 - [User activity tracking](https://github.com/vector-im/mautrix-signal/tree/hs/activity-blocking)
 - [Add additional metrics to the bridge](https://github.com/mautrix/signal/pull/164)
 - [Make handledMatrixMessage log at info, and include more details](https://github.com/vector-im/mautrix-signal/pull/6)
+- [Add ability to disable invites tempoarily](https://github.com/vector-im/mautrix-signal/pull/7)
 
 Some changes that appear here may get upstreamed to https://github.com/mautrix/signal, and will be removed from
 the list when they appear in both versions.

--- a/mautrix_signal/config.py
+++ b/mautrix_signal/config.py
@@ -106,6 +106,7 @@ class Config(BaseBridgeConfig):
         copy("bridge.limits.min_puppet_activity_days")
         copy("bridge.limits.puppet_inactivity_days")
         copy("bridge.limits.block_on_limit_reached")
+        copy("bridge.noop_invites")
 
     def _get_permissions(self, key: str) -> Permissions:
         level = self["bridge.permissions"].get(key, "")

--- a/mautrix_signal/example-config.yaml
+++ b/mautrix_signal/example-config.yaml
@@ -266,6 +266,9 @@ bridge:
         puppet_inactivity_days: 30
         # Should the bridge block traffic when a limit has been reached
         block_on_limit_reached: false
+    
+    # Do not send invites to Matrix users. Use for debugging only.
+    noop_invites: False
 
 # Python logging configuration.
 #

--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -519,7 +519,10 @@ class Portal(DBPortal, BasePortal):
             else:
                 self.log.trace(f"{sender.mxid} reacted to {message.timestamp} with {emoji}")
                 sender.send_remote_checkpoint(
-                    MessageSendCheckpointStatus.SUCCESS, event_id, self.mxid, EventType.REACTION,
+                    MessageSendCheckpointStatus.SUCCESS,
+                    event_id,
+                    self.mxid,
+                    EventType.REACTION,
                 )
                 await self._upsert_reaction(
                     existing, self.main_intent, event_id, sender, message, emoji
@@ -1038,7 +1041,10 @@ class Portal(DBPortal, BasePortal):
         if not pack:
             content.info["fi.mau.signal.sticker"] = {
                 "id": sticker.sticker_id,
-                "pack": {"id": sticker.pack_id, "key": sticker.pack_key,},
+                "pack": {
+                    "id": sticker.pack_id,
+                    "key": sticker.pack_key,
+                },
             }
             return
         sticker_meta = pack.stickers[sticker.sticker_id]
@@ -1046,7 +1052,12 @@ class Portal(DBPortal, BasePortal):
         content.info["fi.mau.signal.sticker"] = {
             "id": sticker.sticker_id,
             "emoji": sticker_meta.emoji,
-            "pack": {"id": pack.id, "key": pack.key, "title": pack.title, "author": pack.author,},
+            "pack": {
+                "id": pack.id,
+                "key": pack.key,
+                "title": pack.title,
+                "author": pack.author,
+            },
         }
 
     @staticmethod
@@ -1316,7 +1327,9 @@ class Portal(DBPortal, BasePortal):
         for address in info.members:
             user = await u.User.get_by_address(address)
             if user:
-                self.log.debug(f"_update_participants info.members inviting {self.mxid} to {user.mxid}")
+                self.log.debug(
+                    f"_update_participants info.members inviting {self.mxid} to {user.mxid}"
+                )
                 if self.config["bridge.noop_invites"] != True:
                     await self.main_intent.invite_user(self.mxid, user.mxid)
 
@@ -1327,13 +1340,17 @@ class Portal(DBPortal, BasePortal):
         for address in pending_members:
             user = await u.User.get_by_address(address)
             if user:
-                self.log.debug(f"_update_participants info.pending_members inviting {self.mxid} to {user.mxid}")
+                self.log.debug(
+                    f"_update_participants info.pending_members inviting {self.mxid} to {user.mxid}"
+                )
                 if self.config["bridge.noop_invites"] != True:
                     await self.main_intent.invite_user(self.mxid, user.mxid)
 
             puppet = await p.Puppet.get_by_address(address)
             await source.sync_contact(address)
-            self.log.debug(f"_update_participants info.pending_members inviting {self.mxid} to {puppet.intent_for(self).mxid}")
+            self.log.debug(
+                f"_update_participants info.pending_members inviting {self.mxid} to {puppet.intent_for(self).mxid}"
+            )
             await self.main_intent.invite_user(self.mxid, puppet.intent_for(self).mxid)
 
     async def _update_power_levels(self, info: ChatInfo) -> None:
@@ -1517,7 +1534,10 @@ class Portal(DBPortal, BasePortal):
                 "state_key": self.bridge_info_state_key,
                 "content": self.bridge_info,
             },
-            {"type": str(EventType.ROOM_POWER_LEVELS), "content": power_levels.serialize(),},
+            {
+                "type": str(EventType.ROOM_POWER_LEVELS),
+                "content": power_levels.serialize(),
+            },
         ]
         invites = []
         if self.config["bridge.encryption.default"] and self.matrix.e2ee:
@@ -1536,7 +1556,10 @@ class Portal(DBPortal, BasePortal):
             name = self.name
         if self.avatar_url:
             initial_state.append(
-                {"type": str(EventType.ROOM_AVATAR), "content": {"url": self.avatar_url},}
+                {
+                    "type": str(EventType.ROOM_AVATAR),
+                    "content": {"url": self.avatar_url},
+                }
             )
 
         creation_content = {}

--- a/mautrix_signal/signal.py
+++ b/mautrix_signal/signal.py
@@ -19,7 +19,6 @@ from typing import TYPE_CHECKING
 import asyncio
 import logging
 
-
 from mausignald import SignaldClient
 from mausignald.types import (
     Address,

--- a/mautrix_signal/user.py
+++ b/mautrix_signal/user.py
@@ -47,7 +47,10 @@ METRIC_CONNECTED = Gauge("bridge_connected", "Bridge users connected to Signal")
 METRIC_LOGGED_IN = Gauge("bridge_logged_in", "Bridge users logged into Signal")
 
 BridgeState.human_readable_errors.update(
-    {"logged-out": "You're not logged into Signal", "signal-not-connected": None,}
+    {
+        "logged-out": "You're not logged into Signal",
+        "signal-not-connected": None,
+    }
 )
 
 


### PR DESCRIPTION
This should hopefully

- Disable invites only when `bridge.noop_invites` is explicitly true.
- Log more details on invites so we can trace further