### PR TITLE
Check existing members in Matrix room and kick any unknown users

### DIFF
--- a/mautrix_signal/portal.py
+++ b/mautrix_signal/portal.py
@@ -1380,10 +1380,10 @@ class Portal(DBPortal, BasePortal):
             except Exception as ex:
                 self.log.warning(f"failed to invite pending_member {address}", ex)
 
-        if len(members_to_drop) == 0:
-            return
-
-        self.log.warning(f"_update_participants is dropping {members_to_drop} from {self.mxid}")
+        if len(members_to_drop) > 0:
+            self.log.warning(
+                f"_update_participants is dropping {members_to_drop} from {self.mxid}"
+            )
         for member in members_to_drop:
             try:
                 await self.main_intent.kick_user(


### PR DESCRIPTION
This is to prevent Matrix users from lurking in rooms should they join without being joined on the Signal side. This *also* cleans up rouge Signal users themselves, if any get left behind.

~~(This likely busts relay mode, so we will need to add a check for that one)~~ This works with relay mode by virtue of kicking nobody.