### PR TITLE
Fix v0->latest DB upgrade

### DIFF
--- a/mautrix_signal/db/upgrade/v00_latest_revision.py
+++ b/mautrix_signal/db/upgrade/v00_latest_revision.py
@@ -18,7 +18,7 @@ from mautrix.util.async_db import Connection
 from . import upgrade_table
 
 
-@upgrade_table.register(description="Initial revision", upgrades_to=9)
+@upgrade_table.register(description="Initial revision", upgrades_to=10)
 async def upgrade_latest(conn: Connection) -> None:
     await conn.execute(
         """CREATE TABLE portal (
@@ -66,7 +66,7 @@ async def upgrade_latest(conn: Connection) -> None:
             base_url     TEXT,
 
             first_activity_ts BIGINT,
-            last_activity_ts BIGINT,
+            last_activity_ts BIGINT
         )"""
     )
     await conn.execute(


### PR DESCRIPTION
Bumping the upgrades_to since it missed its mark
in the last upstream merge-in.