### PR TITLE
Use fork URLs/versions

### DIFF
--- a/mautrix_signal/__init__.py
+++ b/mautrix_signal/__init__.py
@@ -1,2 +1,2 @@
-__version__ = "0.4.0"
+__version__ = "0.4.0-mod-1"
 __author__ = "Tulir Asokan <tulir@maunium.net>"

--- a/mautrix_signal/__main__.py
+++ b/mautrix_signal/__main__.py
@@ -49,7 +49,7 @@ class SignalBridge(Bridge):
     name = "mautrix-signal"
     command = "python -m mautrix-signal"
     description = "A Matrix-Signal puppeting bridge."
-    repo_url = "https://github.com/mautrix/signal"
+    repo_url = "https://github.com/vector-im/mautrix-signal"
     version = version
     markdown_version = linkified_version
     config_class = Config

--- a/mautrix_signal/get_version.py
+++ b/mautrix_signal/get_version.py
@@ -19,7 +19,7 @@ def run(cmd):
 if os.path.exists(".git") and shutil.which("git"):
     try:
         git_revision = run(["git", "rev-parse", "HEAD"]).strip().decode("ascii")
-        git_revision_url = f"https://github.com/mautrix/signal/commit/{git_revision}"
+        git_revision_url = f"https://github.com/vector-im/mautrix-signal/commit/{git_revision}"
         git_revision = git_revision[:8]
     except (subprocess.SubprocessError, OSError):
         git_revision = "unknown"
@@ -34,7 +34,7 @@ else:
     git_revision_url = None
     git_tag = None
 
-git_tag_url = f"https://github.com/mautrix/signal/releases/tag/{git_tag}" if git_tag else None
+git_tag_url = f"https://github.com/vector-im/mautrix-signal/releases/tag/{git_tag}" if git_tag else None
 
 if git_tag and __version__ == git_tag[1:].replace("-", ""):
     version = __version__

--- a/mautrix_signal/get_version.py
+++ b/mautrix_signal/get_version.py
@@ -34,7 +34,9 @@ else:
     git_revision_url = None
     git_tag = None
 
-git_tag_url = f"https://github.com/vector-im/mautrix-signal/releases/tag/{git_tag}" if git_tag else None
+git_tag_url = (
+    f"https://github.com/vector-im/mautrix-signal/releases/tag/{git_tag}" if git_tag else None
+)
 
 if git_tag and __version__ == git_tag[1:].replace("-", ""):
     version = __version__

--- a/setup.py
+++ b/setup.py
@@ -35,9 +35,9 @@ linkified_version = {linkified_version!r}
 setuptools.setup(
     name="mautrix-signal",
     version=version,
-    url="https://github.com/mautrix/signal",
+    url="https://github.com/vector-im/mautrix-signal",
     project_urls={
-        "Changelog": "https://github.com/mautrix/signal/blob/master/CHANGELOG.md",
+        "Changelog": "https://github.com/vector-im/mautrix-signal/blob/master/CHANGELOG.md",
     },
 
     author="Tulir Asokan",


### PR DESCRIPTION
This has a few practical benefits:
- The `version` bot command will link to this fork instead of to upstream. (Links work without this, but they give a warning of `This commit does not belong to any branch on this repository, and may belong to a fork outside of the repository.`)
- The `__version__` property of the Python package will represent our fork's version, which may help for scripting & debugging.